### PR TITLE
Create auth service, spotify-config model for spotify credentials

### DIFF
--- a/Constants.cs
+++ b/Constants.cs
@@ -1,4 +1,6 @@
-﻿namespace mpg_cli
+﻿using SpotifyAPI.Web;
+
+namespace mpg_cli
 {
     public class Constants
     {
@@ -12,6 +14,13 @@
         
         public static readonly string AppName = "mpg_cli";
         public static readonly string AppVersion = "v1.0";
-        
+
+        // 'spotify_config.json' - can hardcode it here, or pass it in as an arg
+        public static readonly string SpotifyConfigPath = @"d:/keystore/mpg-cli/spotify_config.json";
+
+        // Scopes
+        // When updating these, need to call SpotifyPkceAuthService.Authorization() with
+        // param forceReAuth: true
+        public static List<string> SpotifyScopes = new List<string> { Scopes.UserReadEmail };
     }
 }

--- a/Models/SpotifyConfig.cs
+++ b/Models/SpotifyConfig.cs
@@ -1,0 +1,20 @@
+﻿
+using Newtonsoft.Json;
+
+namespace mpg_cli.Models
+{
+    internal class SpotifyConfig
+    {
+        [JsonProperty("credentials_path")]
+        public string? CredentialsPath { get; set; }
+
+        [JsonProperty("client_id")]
+        public string? ClientId { get; set; }
+
+        [JsonProperty("callback_url")]
+        public string? CallbackUrl { get; set; }
+
+        [JsonProperty("port")]
+        public int Port { get; set; }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,15 +1,41 @@
-﻿namespace mpg_cli
+﻿using mpg_cli.Models;
+using mpg_cli.Services;
+using Newtonsoft.Json;
+
+namespace mpg_cli
 {
     internal class Program
     {
-        static void Main(string[] args)
+        static async Task Main(string[] args)
         {
             // Intro
             Console.WriteLine(Constants.AppNameASCII);
             Console.WriteLine(Constants.AppVersion);
 
             // Authorization
-            // @todo
+            Console.WriteLine("Authoriation your account with Spotify.");
+            // @todo: allow this to be passed in as command line arg
+            Console.WriteLine($"Using SpotifyConfig: '{Constants.SpotifyConfigPath}'.");
+
+            if (!File.Exists(Constants.SpotifyConfigPath))
+            {
+                throw new FileNotFoundException(Constants.SpotifyConfigPath);
+            }
+
+            var spotifyConfigContents = File.ReadAllText(Constants.SpotifyConfigPath);
+            var spotifyConfig = JsonConvert.DeserializeObject<SpotifyConfig>(spotifyConfigContents);
+
+            var authService = new SpotifyPkceAuthService(spotifyConfig.CredentialsPath,
+                spotifyConfig.ClientId,
+                spotifyConfig.CallbackUrl,
+                spotifyConfig.Port,
+                Constants.SpotifyScopes);
+
+            var spotifyClient = await authService.Authorize();
+            var profile = await spotifyClient.UserProfile.Current();
+
+            // Greet user
+            Console.WriteLine($"Hello, {profile.DisplayName}!");
         }
     }
 }

--- a/Services/SpotifyPkceAuthService.cs
+++ b/Services/SpotifyPkceAuthService.cs
@@ -1,0 +1,137 @@
+﻿using Newtonsoft.Json;
+
+using SpotifyAPI.Web;
+using SpotifyAPI.Web.Auth;
+
+namespace mpg_cli.Services
+{
+    internal class SpotifyPkceAuthService : IDisposable
+    {
+        private string credentialsPath;
+        private readonly string? clientId;
+        private readonly string callbackUrl;
+        private readonly int port;
+        private readonly List<string> scopes;
+
+        private readonly EmbedIOAuthServer server;
+        private SpotifyClient spotifyClient;
+
+        public SpotifyPkceAuthService(string credentialsPath, string clientId, string callbackUrl, int port, List<string> scopes)
+        {
+            this.credentialsPath = credentialsPath;
+            this.clientId = clientId;
+            this.callbackUrl = callbackUrl;
+            this.port = port;
+            this.scopes = scopes;
+
+            this.server = new EmbedIOAuthServer(new Uri(callbackUrl), port);
+        }
+
+        // forceReAuth needs to be set to true if you are changing scopes around
+        public async Task<SpotifyClient> Authorize(bool forceReAuth = false)
+        {
+            if (!(await NeedsToReAuthorize(forceReAuth)))
+            {
+                await this.Start();
+            }
+            else
+            {
+                await this.StartAuthentication();
+            }
+
+            return this.spotifyClient;
+        }
+
+        private async Task Start()
+        {
+            var json = await File.ReadAllTextAsync(this.credentialsPath);
+            var token = JsonConvert.DeserializeObject<PKCETokenResponse>(json);
+
+            var authenticator = new PKCEAuthenticator(this.clientId, token);
+            authenticator.TokenRefreshed += (sender, token) => File.WriteAllText(this.credentialsPath, JsonConvert.SerializeObject(token));
+
+            var config = SpotifyClientConfig.CreateDefault().WithAuthenticator(authenticator);
+
+            this.spotifyClient = new SpotifyClient(config);
+        }
+
+        private async Task StartAuthentication()
+        {
+            var (verifier, challenge) = PKCEUtil.GenerateCodes();
+
+            await this.server.Start();
+
+            server.AuthorizationCodeReceived += async (sender, response) =>
+            {
+                await this.server.Stop();
+
+                PKCETokenResponse token = await new OAuthClient().RequestToken(
+                    new PKCETokenRequest(this.clientId, response.Code, this.server.BaseUri, verifier)
+                );
+
+                await File.WriteAllTextAsync(this.credentialsPath, JsonConvert.SerializeObject(token));
+
+                await Start();
+            };
+
+            var request = new LoginRequest(this.server.BaseUri, this.clientId, LoginRequest.ResponseType.Code)
+            {
+                CodeChallenge = challenge,
+                CodeChallengeMethod = "S256",
+                Scope = this.scopes
+            };
+
+            var uri = request.ToUri();
+
+            try
+            {
+                Console.WriteLine("Opening your browser to authenticate with Spotify...");
+                BrowserUtil.Open(uri);
+            }
+            catch (Exception)
+            {
+                Console.WriteLine($"Unable to open your browser. Please copy this URL into your browser and open:\n{uri}");
+            }
+
+            Console.WriteLine("****");
+            Console.WriteLine("Press [ENTER] in this window after signing in to Spotify.");
+            Console.WriteLine("****");
+            Console.WriteLine();
+
+            Console.ReadLine();
+        }
+
+        private async Task<bool> NeedsToReAuthorize(bool forceReAuth)
+        {
+            // Paramr passed to parent function is true - forcing re-auth
+            if (forceReAuth) return true;
+
+            // File doesn't exist - create it then return true
+            if (!File.Exists(this.credentialsPath))
+            {
+                File.Create(this.credentialsPath);
+                return true;
+            }
+            
+            // Catches any weird formatting issues in the file leading to de-serialization issues
+            // Most common case is maybe the file exists but has no contents.
+            try
+            {
+                var json = await File.ReadAllTextAsync(this.credentialsPath);
+                var token = JsonConvert.DeserializeObject<PKCETokenResponse>(json);
+            } 
+            catch(Exception)
+            {
+                return true;
+            }
+
+            // If we made it all the way here, I guess we're good...
+            return false;
+        }
+
+        public void Dispose()
+        {
+            this.server.Dispose();
+        }
+    }
+}

--- a/mpg-cli - Backup.csproj
+++ b/mpg-cli - Backup.csproj
@@ -8,9 +8,4 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="SpotifyAPI.Web" Version="7.0.0" />
-    <PackageReference Include="SpotifyAPI.Web.Auth" Version="7.0.0" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
- add values to Constants.cs needed for auth
- added SpotifyConfig model to hold config values needed by the auth service
- Created SpotifyPkceAuthService to handle authorization
- Added SpotifyAPI.Web, SpotifyAPI.Auth nuget packages
- Added call to auth service in Main() method